### PR TITLE
Show visually similar works

### DIFF
--- a/daily-art/main.py
+++ b/daily-art/main.py
@@ -10,7 +10,7 @@ from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
 from .resources.data import ArtWork, get_data, update_data, convert_iiif_width
-
+from .resources.similarity import get_visually_similar_artworks
 from .resources.slack_hook import SlackHook
 
 CHANNEL_ID = 'daily-art-beta'
@@ -37,7 +37,7 @@ def get_random_artwork(width):
     filtered_works[work_id]["full_image_uri"] = convert_iiif_width(
         filtered_works[work_id]["full_image_uri"], width=width
     )
-
+    filtered_works[work_id]["similar_works"] = get_visually_similar_artworks(work_id)
     return filtered_works[work_id]
 
 
@@ -64,6 +64,7 @@ def random_art_slack(width: int = 600, work_id: str = ""):
     """ Posts a random artwork to a given slack hook """
     if work_id:
         work = filtered_works[work_id]
+        work["similar_works"] = get_visually_similar_artworks(work_id)
     else:
         work = get_random_artwork(width=width)
 

--- a/daily-art/resources/data.py
+++ b/daily-art/resources/data.py
@@ -20,13 +20,20 @@ FILTERED_FILENAME = 'filtered_list_of_works.json'
 # pre-annotated.
 
 WELLCOME_DATASET_URL = "https://data.wellcomecollection.org/" \
-                         "catalogue/v2/works.json.gz"
+                       "catalogue/v2/works.json.gz"
 
 S3_DATASET_URL = "https://wellcome-collection-data.s3.eu-west-2" \
                  ".amazonaws.com/annotated-data/filtered_list_of_works.json"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+class SimilarWork(BaseModel):
+    id: str
+    title: str
+    full_image_uri: str
+    collection_url: str
 
 
 class ArtWork(BaseModel):
@@ -36,6 +43,7 @@ class ArtWork(BaseModel):
     full_image_uri: str
     collection_url: str
     contributors: List
+    similar_works: List[SimilarWork]
 
 
 def convert_iiif_width(uri, width="full"):

--- a/daily-art/resources/similarity.py
+++ b/daily-art/resources/similarity.py
@@ -1,0 +1,32 @@
+import requests
+
+
+def get_visually_similar_artworks(work_id: str, n: int = 3):
+    """ Returns a list of `n` visually similar artworks """
+    url = f"https://labs.wellcomecollection.org/feature-similarity/works/{work_id}?n={n}"
+    similarity_req = requests.get(url)
+
+    if similarity_req:
+        return [similarity_api_result_to_similar_work(n) for n in similarity_req.json()["neighbours"]]
+    else:
+        return []
+
+
+def get_title(work_id: str):
+    url = f"https://api.wellcomecollection.org/catalogue/v2/works/{work_id}"
+    work_req = requests.get(url)
+
+    if url:
+        return work_req.json()["title"]
+    else:
+        return ""
+
+
+def similarity_api_result_to_similar_work(neighbour):
+    """ Converts results from the similarity API to the model used in daily-art """
+    return {
+        "id": neighbour["catalogue_id"],
+        "title": get_title(neighbour["catalogue_id"]),
+        "full_image_uri": neighbour["miro_uri"],
+        "collection_url": neighbour["catalogue_uri"]
+    }

--- a/daily-art/resources/slack_hook.py
+++ b/daily-art/resources/slack_hook.py
@@ -13,29 +13,77 @@ class SlackHook(BaseModel):
 
         if len(work['contributors']) > 0:
             try:
-                contributors = "\n\n*Contributors*\n{}".format(
+                contributors = "*Contributors:* {}".format(
                     work['contributors'][0]['agent']['label']
                 )
             except KeyError:
                 contributors = ""
 
-        slack_json = {
-            "attachments": [
-                {
-                    "fallback": "Image not found",
-                    "color": "#36a64f",
-                    "pretext": "*Here is your daily Wellcome art*",
-                    "title": work['title'],
-                    "title_link": work['collection_url'],
-                    "text": "{}{}".format(work['description'], contributors),
-                    "image_url": work['full_image_uri'],
-                    "footer": "Daily-Wellcome-Art API",
-                    "footer_icon": "https://upload.wikimedia.org/wikipedia/"
-                                   "commons/thumb/5/58/"
-                                   "Wellcome_Trust_logo.svg/"
-                                   "1024px-Wellcome_Trust_logo.svg.png"
+        slack_json_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"_Here is your daily Wellcome art:_\n<{work['collection_url']}|*{work['title']}*>"
                 }
-            ]
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "plain_text",
+                    "text": work['description'],
+                }
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": contributors
+                    }
+                ]
+            },
+            {
+                "type": "image",
+                "title": {
+                    "type": "plain_text",
+                    "text": work['title'],
+                },
+                "image_url": work['full_image_uri'],
+                "alt_text": "image1"
+            }
+        ]
+
+        slack_json_similar_divider_and_title = [
+            {
+                "type": "divider"
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Visually similar artworks:*"
+                }
+            }
+        ]
+
+        slack_json_similar_blocks = [{
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"<{similar_work['collection_url']}|*{similar_work['title']}*>"
+            },
+            "accessory": {
+                "type": "image",
+                "image_url": similar_work['full_image_uri'],
+                "alt_text": similar_work['title']
+            }
+        } for similar_work in work['similar_works']]
+
+        all_blocks = slack_json_blocks + slack_json_similar_divider_and_title + slack_json_similar_blocks
+
+        slack_json = {
+            "blocks": all_blocks if slack_json_similar_blocks else slack_json_blocks
         }
 
         return slack_json


### PR DESCRIPTION
This adds 3 visually similar works to the daily art Slack message, using @harrisonpim's feature similarity API from https://github.com/wellcomecollection/data-science/tree/master/apis/feature_similarity.

I used the new API for constructing Slack messages from "blocks", and now they look like this - it's not the most beautiful thing in the world but I couldn't work out anything better.

![image](https://user-images.githubusercontent.com/4429247/75261457-fb62c100-57e2-11ea-9e6e-db90553cf0c4.png)
